### PR TITLE
ADD: new mathjax implementation

### DIFF
--- a/iterativexblock/public/html/iterativexblock_author.html
+++ b/iterativexblock/public/html/iterativexblock_author.html
@@ -1,4 +1,4 @@
-<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule">
+<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule" id="iterative_{{ location }}">
     <div class="iterative-xblock iterative-xblock-style-{{style}}{% if gridlines %} iterative-xblock-gridlines{% endif %}"
         id="{{xblock.type}}{{location}}">
         <div class="exptop">

--- a/iterativexblock/public/html/iterativexblock_instructor.html
+++ b/iterativexblock/public/html/iterativexblock_instructor.html
@@ -1,5 +1,5 @@
 {% if configured %}
-<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule">
+<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule"  id="iterative_{{ location }}">
     <div class="iterative-xblock iterative-xblock-style-{{style}}{% if gridlines %} iterative-xblock-gridlines{% endif %}"
         id="{{xblock.type}}{{location}}">
         <div class="exptop">

--- a/iterativexblock/public/html/iterativexblock_student.html
+++ b/iterativexblock/public/html/iterativexblock_student.html
@@ -1,5 +1,5 @@
 {% if configured %}
-<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule">
+<div class="iterative-xblock-container_block xmodule_display xmodule_HtmlModule"  id="interative_{{ location }}">
     <div class="iterative-xblock iterative-xblock-style-{{style}}{% if gridlines %} iterative-xblock-gridlines{% endif %}"
         id="{{xblock.type}}{{location}}">
         <div class="exptop">

--- a/iterativexblock/public/js/iterativexblock_author.js
+++ b/iterativexblock/public/js/iterativexblock_author.js
@@ -1,6 +1,22 @@
 function IterativeXBlockAuthor(runtime, element, settings) {
 
     $(function ($) {
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub]); 
+        var iteraid = "iterative_" + settings.location;
+        //console.log(iteraid);
+		renderMathForSpecificElements(iteraidx);
     });
+
+    function renderMathForSpecificElements(id) {
+        //console.log("Render Mathjax in " + id);
+        if (typeof MathJax !== "undefined") {
+            var $container = $('#' + id);
+            if ($container.length) {
+                $container.find('.exptop, .expmid, .expbot').each(function (index, contaelem) {
+                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, contaelem]);
+                });
+            }
+        } else {
+            console.warn("MathJax no está cargado.");
+        }
+    }
 }

--- a/iterativexblock/public/js/iterativexblock_instructor.js
+++ b/iterativexblock/public/js/iterativexblock_instructor.js
@@ -55,6 +55,23 @@ function IterativeXBlockInstructor(runtime, element, settings) {
                 showErrorMessage("Algo salió mal.");
             }
         });
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub]); 
+        
+        var iteraid = "iterative_" + settings.location;
+        //console.log(iteraid);
+		renderMathForSpecificElements(iteraidx);
     });
+
+    function renderMathForSpecificElements(id) {
+        //console.log("Render Mathjax in " + id);
+        if (typeof MathJax !== "undefined") {
+            var $container = $('#' + id);
+            if ($container.length) {
+                $container.find('.exptop, .expmid, .expbot').each(function (index, contaelem) {
+                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, contaelem]);
+                });
+            }
+        } else {
+            console.warn("MathJax no está cargado.");
+        }
+    }
 }

--- a/iterativexblock/public/js/iterativexblock_student.js
+++ b/iterativexblock/public/js/iterativexblock_student.js
@@ -149,7 +149,6 @@ function IterativeXBlockStudent(runtime, element, settings) {
     });
 
     $(function ($) {
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         $.post(ensureUrl, JSON.stringify({})).done(function (response) {
             if (response["result"] !== "success") {
                 showErrorMessage("Algo salió mal.");
@@ -168,5 +167,24 @@ function IterativeXBlockStudent(runtime, element, settings) {
         statusDiv.removeClass("unanswered");
         statusDiv.addClass("correct");
         statusDiv.addClass(settings.indicator_class);
+        
+
+        var iteraid = "iterative_" + settings.location;
+        //console.log(iteraid)
+		renderMathForSpecificElements(iteraid);
     });
+
+    function renderMathForSpecificElements(id) {
+        //console.log("Render Mathjax in " + id);
+        if (typeof MathJax !== "undefined") {
+            var $container = $('#' + id);
+            if ($container.length) {
+                $container.find('.exptop, .expmid, .expbot').each(function (index, contaelem) {
+                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, contaelem]);
+                });
+            }
+        } else {
+            console.warn("MathJax no está cargado.");
+        }
+    }
 }


### PR DESCRIPTION
nueva implementación de mathjax mirar la  funcion

```javascript
function renderMathForSpecificElements(id) {
        //console.log("Render Mathjax in " + id);
        if (typeof MathJax !== "undefined") {
            var $container = $('#' + id);
            if ($container.length) {
                $container.find('.exptop, .expmid, .expbot').each(function (index, contaelem) {
                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, contaelem]);
                });
            }
        } else {
            console.warn("MathJax no está cargado.");
        }
    }
``` 

Dado que el iterativo tiene una similitud muy parecida al container en estructura 
estos son los los elementos que pueden contener texto con mathjax

-exptop
-expmid
-expbot

podría tambien ser mas especifico y aplicarse celda por celda y en los botones